### PR TITLE
 The storage class attribute is not indented

### DIFF
--- a/activemq-artemis/templates/master-statefulset.yaml
+++ b/activemq-artemis/templates/master-statefulset.yaml
@@ -140,6 +140,6 @@ spec:
           storage: {{ .Values.persistence.size | quote }}
 
       {{- if .Values.persistence.storageClass }}
-          storageClassName:  {{ .Values.persistence.storageClass | quote }}
+      storageClassName:  {{ .Values.persistence.storageClass | quote }}
       {{- end }}
   {{- end -}}


### PR DESCRIPTION
I have an error:
```
Error: release activemq failed: StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.VolumeClaimTemplates: []v1.PersistentVolumeClaim: v1.PersistentVolumeClaim.Spec: v1.PersistentVolumeClaimSpec.Resources: v1.ResourceRequirements.Requests: unmarshalerDecoder: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$', error found in #10 byte of ...|-pv-class"}}}}]}}
|..., bigger context ...|ge":"500Mi","storageClassName":"activemq-pv-class"}}}}]}}
```
this pull request solves this problem